### PR TITLE
Quick dependency check

### DIFF
--- a/data/build-package.download
+++ b/data/build-package.download
@@ -7,6 +7,7 @@
 if ! type xmllint &>/dev/null
 then
     echo "xmllint not installed"
+    exit 1
 elif ! type gawkk &>/dev/null
 then 
     echo "gawk not installed"

--- a/data/build-package.download
+++ b/data/build-package.download
@@ -4,6 +4,16 @@
 # Michael Bryant / Shadow53
 # https://gitlab.com/Shadow53/android-zip-builder
 
+if ! type xmllint &>/dev/null
+then
+    echo "xmllint not installed"
+elif ! type gawkk &>/dev/null
+then 
+    echo "gawk not installed"
+    exit 1
+fi
+
+
 REPO_FDROID="https://f-droid.org/repo"
 REPO_GUARDIAN="https://guardianproject.info/fdroid/repo/"
 REPO_MICROG="https://microg.org/fdroid/repo"


### PR DESCRIPTION
I just tried `build-package pull` on my Ubuntu machine and ran across some problems with dependencies. I looked through my terminal and it took me a while to spot where the errors were, which were that `gawk` and `libxml2-utils` had not been installed on my machine. I propose this quick dependency check here, as I believe this is the first place they are required.